### PR TITLE
fix: use parallel-web-cli package name in setup docs/message

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A [pi](https://github.com/badlogic/pi-mono) extension that gives your agent web 
 Sign up at [parallel.ai](https://parallel.ai), then install and authenticate the CLI:
 
 ```bash
-npm install -g @parallel-web/cli
+npm install -g parallel-web-cli
 parallel-cli login
 ```
 

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -21,7 +21,7 @@ export default function (pi: ExtensionAPI) {
         version = execSync("parallel-cli --version", { encoding: "utf-8" }).trim();
       } catch {
         ctx.ui.notify(
-          "✗ parallel-cli not found\n\nInstall it:\n  npm install -g @parallel-web/cli\n\nThen authenticate:\n  parallel-cli login",
+          "✗ parallel-cli not found\n\nInstall it:\n  npm install -g parallel-web-cli\n\nThen authenticate:\n  parallel-cli login",
           "error"
         );
         return;


### PR DESCRIPTION
## Summary
- replace deprecated/incorrect package reference `@parallel-web/cli` with `parallel-web-cli`
- update both the README setup command and `/parallel-setup` install hint

## Why
Current install instructions point to the wrong package name, causing setup confusion/failures for users.